### PR TITLE
Update to fix upwards flow bug

### DIFF
--- a/examples/pour_test_up.json
+++ b/examples/pour_test_up.json
@@ -2,7 +2,7 @@
 	"simulation" : {
 		"r_pebble" : 0.03,
 		"t_final" : 3600,
-		"pf" : 0.20,
+		"pf" : 0.30,
 		"down_flow" : false
 	},
 	"core_intake" : {
@@ -11,7 +11,7 @@
 			"x_c" : 0.0,
 			"y_c" : 0.0,
 			"z_max" : -0.1,
-			"z_min" : -0.2,
+			"z_min" : -0.4,
 			"r": 0.24,
 			"open_bottom" : "",
 			"open_top" : "open 2"
@@ -22,8 +22,8 @@
 			"y_c" : 0.0,
 			"z_max" : 0.0,
 			"z_min" : -0.1,
-			"r_upper" : 0.24,
-			"r_lower" : 1.2,
+			"r_upper" : 1.2,
+			"r_lower" : 0.24,
 			"open_bottom" : "open 1",
 			"open_top" : "open 2"
 		}
@@ -38,17 +38,6 @@
 			"r" : 1.2,
 			"open_bottom" : "open 1",
 			"open_top" : "open 2"
-		},
-		"main_cone" : {
-			"type" : "cone",
-			"x_c" : 0.0,
-			"y_c" : 0.0,
-			"z_max" : 10.0,
-			"z_min" : 9.46,
-			"r_upper" : 1.2,
-			"r_lower" : 0.24,
-			"open_bottom" : "open 1",
-			"open_top" : "open 2"
 		}
 	},
 	"core_outtake" : {
@@ -61,6 +50,17 @@
 			"r" : 0.24,
 			"open_bottom" : "open 1",
 			"open_top" : ""
+		},
+		"outtake_cone" : {
+			"type" : "cone",
+			"x_c" : 0.0,
+			"y_c" : 0.0,
+			"z_max" : 10.0,
+			"z_min" : 9.46,
+			"r_upper" : 0.24,
+			"r_lower" : 1.2,
+			"open_bottom" : "open 1",
+			"open_top" : "open 2"
 		}
 	},
 	"lammps_var" : {

--- a/examples/pour_test_up.json
+++ b/examples/pour_test_up.json
@@ -2,15 +2,16 @@
 	"simulation" : {
 		"r_pebble" : 0.03,
 		"t_final" : 3600,
-		"pf" : 0.60
+		"pf" : 0.30,
+		"down_flow" : false
 	},
 	"core_intake" : {
 		"intake_cyl" : {
 			"type" : "cylinder",
 			"x_c" : 0.0,
 			"y_c" : 0.0,
-			"z_max" : 10.2,
-			"z_min" : 10.1,
+			"z_max" : -0.1,
+			"z_min" : -0.2,
 			"r": 0.24,
 			"open_bottom" : "open 1",
 			"open_top" : "open 2"
@@ -19,8 +20,8 @@
 			"type" : "cone",
 			"x_c" : 0.0,
 			"y_c" : 0.0,
-			"z_max" : 10.1,
-			"z_min" : 10.0,
+			"z_max" : 0.0,
+			"z_min" : -0.1,
 			"r_upper" : 0.24,
 			"r_lower" : 1.2,
 			"open_bottom" : "open 1",
@@ -32,8 +33,8 @@
 			"type" : "cylinder",
 			"x_c" : 0.0,
 			"y_c" : 0.0,
-			"z_max" : 10.0,
-			"z_min" : 0.54,
+			"z_max" : 9.46,
+			"z_min" : 0.0,
 			"r" : 1.2,
 			"open_bottom" : "open 1",
 			"open_top" : "open 2"
@@ -42,8 +43,8 @@
 			"type" : "cone",
 			"x_c" : 0.0,
 			"y_c" : 0.0,
-			"z_max" : 0.54,
-			"z_min" : 0.0,
+			"z_max" : 10.0,
+			"z_min" : 9.46,
 			"r_upper" : 1.2,
 			"r_lower" : 0.24,
 			"open_bottom" : "open 1",
@@ -55,11 +56,11 @@
 			"type" : "cylinder",
 			"x_c" : 0.0,
 			"y_c" : 0.0,
-			"z_max" : 0.0,
-			"z_min" : -1.34,
+			"z_max" : 11.34,
+			"z_min" : 10.0,
 			"r" : 0.24,
-			"open_bottom" : "",
-			"open_top" : "open 2"
+			"open_bottom" : "open 1",
+			"open_top" : ""
 		}
 	},
 	"lammps_var" : {
@@ -69,7 +70,7 @@
 		"poisson" : 0.12,
 		"co_fric" : 0.035,
 		"co_rest" : 0.02,
-		"run_factor" : 20,
+		"run_factor" : 5,
 		"interval" : 500000
 	}
 }

--- a/examples/pour_test_up.json
+++ b/examples/pour_test_up.json
@@ -2,7 +2,7 @@
 	"simulation" : {
 		"r_pebble" : 0.03,
 		"t_final" : 3600,
-		"pf" : 0.30,
+		"pf" : 0.60,
 		"down_flow" : false
 	},
 	"core_intake" : {
@@ -70,7 +70,7 @@
 		"poisson" : 0.12,
 		"co_fric" : 0.035,
 		"co_rest" : 0.02,
-		"run_factor" : 5,
+		"run_factor" : 15,
 		"interval" : 500000
 	}
 }

--- a/examples/pour_test_up.json
+++ b/examples/pour_test_up.json
@@ -2,7 +2,7 @@
 	"simulation" : {
 		"r_pebble" : 0.03,
 		"t_final" : 3600,
-		"pf" : 0.60,
+		"pf" : 0.20,
 		"down_flow" : false
 	},
 	"core_intake" : {
@@ -13,7 +13,7 @@
 			"z_max" : -0.1,
 			"z_min" : -0.2,
 			"r": 0.24,
-			"open_bottom" : "open 1",
+			"open_bottom" : "",
 			"open_top" : "open 2"
 		},
 		"intake_cone" : {

--- a/ghastly/core.py
+++ b/ghastly/core.py
@@ -8,7 +8,7 @@ class Core:
     '''
 
     def __init__(self, x_c, y_c, z_max, z_min, regions=[],
-                 open_bottom="open 1"):
+                 open_bottom="open 1", open_top="open 2"):
         '''
         Initializes a single instance of a Core object.
 
@@ -37,6 +37,7 @@ class Core:
         self.z_min = z_min
         self.regions = regions
         self.open_bottom = open_bottom
+        self.open_top = open_top
         self.h = z_max - z_min
 
 

--- a/ghastly/ghastly.py
+++ b/ghastly/ghastly.py
@@ -334,7 +334,26 @@ def write_settle_block(settle_filename, sim_block, reg_files, reg_names):
     '''
     write lammps code block that adds the outtake region to the simulation
     and reverses gravity, allowing pebbles to settle upwards after pouring
-    for upwards flowing systems
+    for upwards flowing systems.
+
+    Parameters
+    ----------
+    settle_filename : str
+        name of the LAMMPS input file that will be created.
+    sim_block : Ghastly Sim object
+        Ghastly Sim object containing simulation-specific parameters.
+        Generally created automatically from an input file.
+    reg_files : list
+        List of strings, where each string is the list of region files that
+        have been created during the automatic input file creation process.
+    reg_names : list
+        List of strings, where each string is the ID of the region
+        corresponding to the region file with the same index in reg_files.
+
+    Returns
+    -------
+    settle_filename : file
+        Generated file with the same name as settle_filename.
     '''
 
     out_reg_files, out_reg_names = write_region_blocks(sim_block.core_outtake)

--- a/ghastly/ghastly.py
+++ b/ghastly/ghastly.py
@@ -46,7 +46,7 @@ def fill_core(input_file, rough_pf):
             pack_zones = sim_block.core_main | sim_block.core_outtake
         case False:
             pack_zones = sim_block.core_main | sim_block.core_intake
-    
+
     for element in pack_zones.values():
         if type(element) == ghastly.core.CylCore:
             coords = pack_cyl(sim_block, element, rough_pf)
@@ -54,13 +54,13 @@ def fill_core(input_file, rough_pf):
         else:
             pass
 
-    #because pebbles will settle into the outtake region, the target number
-    #of pebbles is calculated using an assumed 0.6 pf in the outtake region,
-    #and the target pf in the main region
-    outtake_volume = sum([i.volume for i in sim_block.core_outtake.values()])
-    main_volume = sum([i.volume for i in sim_block.core_main.values()])
-    n_pebbles = int(np.floor((0.60*outtake_volume)/sim_block.pebble_volume) +
-                np.floor((sim_block.pf*main_volume)/sim_block.pebble_volume))
+    # because pebbles will settle into the outtake region, the target number
+    # of pebbles is calculated using an assumed 0.6 pf in the outtake region,
+    # and the target pf in the main region
+    outtake_vol = sum([i.volume for i in sim_block.core_outtake.values()])
+    main_vol = sum([i.volume for i in sim_block.core_main.values()])
+    n_pebbles = int(np.floor((0.60*outtake_vol)/sim_block.pebble_volume) +
+                    np.floor((sim_block.pf*main_vol)/sim_block.pebble_volume))
     print("Equivalent number of pebbles is "+str(n_pebbles))
 
     pebbles_left = n_pebbles - len(rough_pack)
@@ -72,7 +72,7 @@ def fill_core(input_file, rough_pf):
     x_b, y_b, z_b = find_box_bounds(sim_block, pour=True)
 
     write_lammps_dump_file(rough_pack, "rough-pack.txt", "ff ff ff",
-                   x_b, y_b, z_b)
+                           x_b, y_b, z_b)
 
     variable_filename = "pour_variables.txt"
     write_variable_block(variable_filename, input_block, sim_block)
@@ -85,8 +85,8 @@ def fill_core(input_file, rough_pf):
     write_pour_main(pour_filename, sim_block, variable_filename, x_b, y_b, z_b,
                     reg_files, reg_names, pebbles_left)
 
-    #lmp = lammps()
-    #lmp.file(pour_filename)
+    # lmp = lammps()
+    # lmp.file(pour_filename)
 
 
 def pack_cyl(sim_block, element, rough_pf):
@@ -195,7 +195,7 @@ def find_box_bounds(sim_block, pour=False):
 
 
 def write_lammps_dump_file(coords, dump_filename, bound_conds,
-                   x_b, y_b, z_b):
+                           x_b, y_b, z_b):
     '''
     Using the coordinate array and simulation boundary conditions and
     dimentions, this function uses a jinja template
@@ -227,7 +227,7 @@ def write_lammps_dump_file(coords, dump_filename, bound_conds,
     '''
 
     pebble_coords = [{"id": i, "x": v[0], "y": v[1], "z": v[2]}
-                for i, v in enumerate(coords)]
+                     for i, v in enumerate(coords)]
 
     dump_template = env.get_template("dump_template.txt")
     dump_text = dump_template.render(n_rough_pack=len(coords),
@@ -330,6 +330,7 @@ def write_region_blocks(core_zones):
 
     return reg_files, reg_names
 
+
 def write_settle_block(settle_filename, sim_block, reg_files, reg_names):
     '''
     write lammps code block that adds the outtake region to the simulation
@@ -358,16 +359,14 @@ def write_settle_block(settle_filename, sim_block, reg_files, reg_names):
 
     out_reg_files, out_reg_names = write_region_blocks(sim_block.core_outtake)
     out_reg_names += reg_names
-    
+
     settle_template = env.get_template("settle_template.txt")
     settle_text = settle_template.render(out_reg_files=out_reg_files,
                                          n_regions=len(out_reg_names),
                                          region_names=out_reg_names)
-    
-    
+
     with open(settle_filename, mode='w') as f:
         f.write(settle_text)
-
 
 
 def write_pour_main(pour_filename, sim_block, variable_filename, x_b, y_b, z_b,
@@ -404,7 +403,7 @@ def write_pour_main(pour_filename, sim_block, variable_filename, x_b, y_b, z_b,
     '''
 
     main_core_z_max = max([(key, element.z_max)
-                    for key, element in sim_block.core_main.items()])
+                           for key, element in sim_block.core_main.items()])
     main_intake = sim_block.core_main[main_core_z_max[0]]
 
     x_c_pour = main_intake.x_c
@@ -413,7 +412,7 @@ def write_pour_main(pour_filename, sim_block, variable_filename, x_b, y_b, z_b,
     z_min_pour = main_core_z_max[1] + 0.01
 
     if type(main_intake) == ghastly.core.CylCore:
-        r_pour= 0.75*main_intake.r
+        r_pour = 0.75*main_intake.r
     elif type(main_intake) == ghastly.core.ConeCore:
         r_pour = 0.75*main_intake.r_upper
 
@@ -438,11 +437,8 @@ def write_pour_main(pour_filename, sim_block, variable_filename, x_b, y_b, z_b,
                                      z_min_pour=z_min_pour,
                                      z_max_pour=z_max_pour,
                                      pebbles_left=pebbles_left,
-                                     settle = settle)
+                                     settle=settle)
 
     pour_filename = "pour_main_input.txt"
     with open(pour_filename, mode='w') as f:
         f.write(main_text)
-
-     
-

--- a/ghastly/ghastly.py
+++ b/ghastly/ghastly.py
@@ -85,8 +85,8 @@ def fill_core(input_file, rough_pf):
     write_pour_main(pour_filename, sim_block, variable_filename, x_b, y_b, z_b,
                     reg_files, reg_names, pebbles_left)
 
-    lmp = lammps()
-    lmp.file(pour_filename)
+    #lmp = lammps()
+    #lmp.file(pour_filename)
 
 
 def pack_cyl(sim_block, element, rough_pf):
@@ -338,12 +338,16 @@ def write_settle_block(settle_filename, sim_block, reg_files, reg_names):
     '''
 
     out_reg_files, out_reg_names = write_region_blocks(sim_block.core_outtake)
-    reg_files += out_reg_files
-    reg_names += out_reg_names
-    #from here, you need to create the settle block using the settle_template
-    #the most complicated part will be the region loop, but you can copy the
-    #steps the main file uses to create its region in the first place
-
+    out_reg_names += reg_names
+    
+    settle_template = env.get_template("settle_template.txt")
+    settle_text = settle_template.render(out_reg_files=out_reg_files,
+                                         n_regions=len(out_reg_names),
+                                         region_names=out_reg_names)
+    
+    
+    with open(settle_filename, mode='w') as f:
+        f.write(settle_text)
 
 
 
@@ -398,12 +402,6 @@ def write_pour_main(pour_filename, sim_block, variable_filename, x_b, y_b, z_b,
         case True:
             settle = [""]
         case _:
-            #settle = ["unfix            fill_core", 
-            #          "unfix            grav",
-            #    "fix              grav all gravity ${gravity} vector 0 0 1",
-            #          "run              ${interval}", 
-            #          "run              ${interval}",
-            #          "run              ${interval}"]
             write_settle_block("settle.txt", sim_block, reg_files, reg_names)
             settle = "include           settle.txt"
 

--- a/ghastly/ghastly.py
+++ b/ghastly/ghastly.py
@@ -75,8 +75,8 @@ def fill_core(input_file, rough_pf):
     write_pour_main(pour_filename, sim_block, variable_filename, x_b, y_b, z_b,
                     reg_files, reg_names, pebbles_left)
 
-    #lmp = lammps()
-    #lmp.file(pour_filename)
+    lmp = lammps()
+    lmp.file(pour_filename)
 
 
 def pack_cyl(sim_block, element, rough_pf):

--- a/ghastly/ghastly.py
+++ b/ghastly/ghastly.py
@@ -85,8 +85,6 @@ def fill_core(input_file, rough_pf):
     write_pour_main(pour_filename, sim_block, variable_filename, x_b, y_b, z_b,
                     reg_files, reg_names, pebbles_left)
 
-    # lmp = lammps()
-    # lmp.file(pour_filename)
 
 
 def pack_cyl(sim_block, element, rough_pf):
@@ -333,14 +331,14 @@ def write_region_blocks(core_zones):
 
 def write_settle_block(settle_filename, sim_block, reg_files, reg_names):
     '''
-    write lammps code block that adds the outtake region to the simulation
+    Write lammps code block that adds the outtake region to the simulation
     and reverses gravity, allowing pebbles to settle upwards after pouring
     for upwards flowing systems.
 
     Parameters
     ----------
     settle_filename : str
-        name of the LAMMPS input file that will be created.
+        Name of the LAMMPS input file that will be created.
     sim_block : Ghastly Sim object
         Ghastly Sim object containing simulation-specific parameters.
         Generally created automatically from an input file.

--- a/ghastly/read_input.py
+++ b/ghastly/read_input.py
@@ -81,36 +81,23 @@ class InputBlock:
         core_block = {}
         for key, val in core_zone.items():
             if val["type"].casefold() == "cylinder":
-                if val["open_bottom"] == True:
-                    core_block[key] = core.CylCore(x_c=val["x_c"],
-                                                   y_c=val["y_c"],
-                                                   z_max=val["z_max"],
-                                                   z_min=val["z_min"],
-                                                   r=val["r"])
-                else:
-                    core_block[key] = core.CylCore(x_c=val["x_c"],
-                                                   y_c=val["y_c"],
-                                                   z_max=val["z_max"],
-                                                   z_min=val["z_min"],
-                                                   r=val["r"],
-                                                   open_bottom="")
+                core_block[key] = core.CylCore(x_c=val["x_c"],
+                                               y_c=val["y_c"],
+                                               z_max=val["z_max"],
+                                               z_min=val["z_min"],
+                                               r=val["r"],
+                                               open_bottom=val["open_bottom"],
+                                               open_top=val["open_top"])
 
             elif val["type"].casefold() == "cone":
-                if val["open_bottom"] == True:
-                    core_block[key] = core.ConeCore(x_c=val["x_c"],
-                                                    y_c=val["y_c"],
-                                                    z_max=val["z_max"],
-                                                    z_min=val["z_min"],
-                                                    r_upper=val["r_upper"],
-                                                    r_lower=val["r_lower"])
-                else:
-                    core_block[key] = core.ConeCore(x_c=val["x_c"],
-                                                    y_c=val["y_c"],
-                                                    z_max=val["z_max"],
-                                                    z_min=val["z_min"],
-                                                    r_upper=val["r_upper"],
-                                                    r_lower=val["r_lower"],
-                                                    open_bottom="")
+                core_block[key] = core.ConeCore(x_c=val["x_c"],
+                                                y_c=val["y_c"],
+                                                z_max=val["z_max"],
+                                                z_min=val["z_min"],
+                                                r_upper=val["r_upper"],
+                                                r_lower=val["r_lower"],
+                                                open_bottom=val["open_bottom"],
+                                                open_top=val["open_top"])
             else:
                 raise NameError("Type must be cylinder or cone.")
 

--- a/ghastly/templates/conecore_template.txt
+++ b/ghastly/templates/conecore_template.txt
@@ -1,3 +1,3 @@
 region		{{region_name}} cone z {{x_c}} {{y_c}} {{r_lower}} {{r_upper}} &
 		{{z_min}} {{z_max}} side in units box &
-		{{open_bottom}} open 2
+		{{open_bottom}} {{open_top}}

--- a/ghastly/templates/cylcore_template.txt
+++ b/ghastly/templates/cylcore_template.txt
@@ -1,3 +1,3 @@
 region		{{region_name}} cylinder z {{x_c}} {{y_c}} {{r}} &
 		{{z_min}} {{z_max}} side in units box &
-		{{open_bottom}} open 2
+		{{open_bottom}} {{open_top}}

--- a/ghastly/templates/pour_main.txt
+++ b/ghastly/templates/pour_main.txt
@@ -1,4 +1,6 @@
+suffix		omp
 units		si
+package		omp 4
 
 ##############################################################################
 #variables
@@ -34,7 +36,7 @@ region		bounds block &
 		{{x_b.low}} {{x_b.up}} {{y_b.low}} {{y_b.up}} {{z_b.low}} {{z_b.up}}
 create_box	1 bounds
 
-pair_style	gran/hertz/history &
+pair_style	gran/hertz/history/omp &
 		${k_n} ${k_t} ${gamma_n} ${gamma_t} ${co_fric} 1
 pair_coeff	* *
 
@@ -100,9 +102,7 @@ fix		fill_core all pour {{pebbles_left}} 1 ${seed} region pour_reg &
 
 run		${tot_run}
 
-{% for line in settle -%}
-{{line}}
-{% endfor -%}
+{{settle}}
 
 
 

--- a/ghastly/templates/pour_main.txt
+++ b/ghastly/templates/pour_main.txt
@@ -63,7 +63,7 @@ region		whole_core union {{n_regions}} &
 {% endfor -%}
 		{{region_names[-1]}}
 
-fix		grav all gravity ${gravity} vector {{flow_vector}}
+fix		grav all gravity ${gravity} vector 0 0 -1
 fix		nve_int all nve/sphere
 fix		wall_gran all wall/gran/region hertz/history &
 		${k_n} ${k_t} ${gamma_n} ${gamma_t} ${co_fric} 1 &
@@ -99,6 +99,10 @@ fix		fill_core all pour {{pebbles_left}} 1 ${seed} region pour_reg &
 		diam one ${d_pebble} dens ${density_rho} ${density_rho} vol 0.25 250
 
 run		${tot_run}
+
+{% for line in settle -%}
+{{line}}
+{% endfor -%}
 
 
 

--- a/ghastly/templates/settle_template.txt
+++ b/ghastly/templates/settle_template.txt
@@ -1,6 +1,9 @@
 unfix		fill_core
 unfix		grav
 unfix		wall_gran
+{% for filename in out_reg_files -%}
+include		{{filename}}
+{% endfor -%}
 
 region		whole_core delete
 region		whole_core union {{n_regions}} &

--- a/ghastly/templates/settle_template.txt
+++ b/ghastly/templates/settle_template.txt
@@ -1,0 +1,19 @@
+unfix		fill_core
+unfix		grav
+unfix		wall_gran
+
+region		whole_core delete
+region		whole_core union {{n_regions}} &
+{%		for name in region_names[0:-1] -%}
+		{{name}} &
+{% endfor -%}
+		{{region_names[-1]}}
+
+fix		grav all gravity ${gravity} vector 0 0 1
+fix		wall_gran all wall/gran/region hertz/history &
+		${k_n} ${k_t} ${gamma_n} ${gamma_t} ${co_fric} 1 &
+		region whole_core
+
+run		${interval}
+run		${interval}
+run		${interval}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,3 @@ path = "ghastly/__about__.py"
 
 [tool.hatch.metadata]
 allow-direct-references = false
-
-[tool.pytest.ini_options]
-pythonpath = [".", "tests", "ghastly"]
-testpaths = ["tests"]

--- a/tests/sample_input.json
+++ b/tests/sample_input.json
@@ -12,7 +12,8 @@
 			"z_max" : 1.2,
 			"z_min" : 1.1,
 			"r": 0.1,
-			"open_bottom" : true
+			"open_bottom" : "open 1",
+			"open_top" : "open 2"
 		},
 		"intake_cone" : {
 			"type" : "cone",
@@ -22,7 +23,8 @@
 			"z_min" : 1.0,
 			"r_upper" : 0.1,
 			"r_lower" : 0.5,
-			"open_bottom" : true
+			"open_bottom" : "open 1",
+			"open_top" : "open 2"
 		}
 	},
 	"core_main" : {
@@ -33,7 +35,8 @@
 			"z_max" : 1.0,
 			"z_min" : 0.1,
 			"r" : 0.5,
-			"open_bottom" : true
+			"open_bottom" : "open 1",
+			"open_top" : "open 2"
 		},
 		"main_cone" : {
 			"type" : "cone",
@@ -43,7 +46,8 @@
 			"z_min" : 0.0,
 			"r_upper" : 0.5,
 			"r_lower" : 0.1,
-			"open_bottom" : true
+			"open_bottom" : "open 1",
+			"open_top" : "open 2"
 		}
 	},
 	"core_outtake" : {
@@ -54,7 +58,8 @@
 			"z_max" : 0.0,
 			"z_min" : -0.1,
 			"r" : 0.1,
-			"open_bottom" : true
+			"open_bottom" : "",
+			"open_top" : "open 2"
 		}
 	},
 	"lammps_var" : {


### PR DESCRIPTION
## Summary of changes
Currently, Ghastly has no issue with filling a core with downwards-flowing pebbles, but trying to use the flag for upwards flow would result in an incorrectly-made LAMMPS input.  This PR correctly implements the flag so that upwards and downwards flowing cores can be filled with pebbles.  In addition to changes to the existing files and functions a new template file, settle_template.txt, has been created; there is a new function called write_settle_block in ghastly.py; and a new example input, pour_test_up.json was added to show an upwards-flowing core.

In more detail:  LAMMPS does not allow for the pour fix to be used when the gravity vector is not pointing down.  In order to fill the core initially, the pour fix is used with gravity pointing down.  Once the core has been filled with the appropriate number of pebbles, the region and gravity commands and fixes are re-defined to add the outtake region back to the core, and allow the pebbles to settle under the correct upwards-flowing gravity vector.



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Associated Issues and PRs

- Issue: closes #20 


## Checklist for Reviewers

Reviewers should use [this link](https://arfc.github.io/manual/guides/pull_requests) to get to the
Review Checklist before they begin their review.
