### PR TITLE
fixed small typo with the settle input if pouring down

### DIFF
--- a/ghastly/ghastly.py
+++ b/ghastly/ghastly.py
@@ -416,7 +416,7 @@ def write_pour_main(pour_filename, sim_block, variable_filename, x_b, y_b, z_b,
 
     match sim_block.down_flow:
         case True:
-            settle = [""]
+            settle = ""
         case _:
             write_settle_block("settle.txt", sim_block, reg_files, reg_names)
             settle = "include           settle.txt"


### PR DESCRIPTION
## Summary of changes
This just makes a very small fix to the "settle" variable in write_pour_main - I accidentally kept it as a list for a downwards flowing system, when it should have just been an empty string.


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


## Checklist for Reviewers

Reviewers should use [this link](https://arfc.github.io/manual/guides/pull_requests) to get to the
Review Checklist before they begin their review.
